### PR TITLE
fix: resolve critical issues from code review (v0.0.11)

### DIFF
--- a/1-Scripts/Editor/Utils/Inspector/Attributes/EnumWithDescriptionDrawer.cs
+++ b/1-Scripts/Editor/Utils/Inspector/Attributes/EnumWithDescriptionDrawer.cs
@@ -1,3 +1,4 @@
+#if ODIN_INSPECTOR
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;
@@ -20,9 +21,8 @@ namespace AnkleBreaker.Utils.Inspector.Editor
             // Draw the description info box above the enum dropdown if description exists
             if (!string.IsNullOrEmpty(description))
             {
-                // Créez une zone d'affichage pour l'info box au-dessus
                 GUILayout.BeginVertical();
-                GUILayout.Space(5); // Un peu d'espace entre l'info box et l'élément enum
+                GUILayout.Space(5);
                 SirenixEditorGUI.InfoMessageBox(description);
                 GUILayout.EndVertical();
             }
@@ -51,3 +51,4 @@ namespace AnkleBreaker.Utils.Inspector.Editor
         }
     }
 }
+#endif

--- a/1-Scripts/Editor/Utils/Inspector/Attributes/ReadOnlyEnumFlagsDrawer.cs
+++ b/1-Scripts/Editor/Utils/Inspector/Attributes/ReadOnlyEnumFlagsDrawer.cs
@@ -1,7 +1,8 @@
-﻿using UnityEditor;
+﻿using AnkleBreaker.Utils.Inspector;
+using UnityEditor;
 using UnityEngine;
 
-namespace AnkleBreakerEditorUtils
+namespace AnkleBreaker.Utils.Inspector.Editor
 {
     [CustomPropertyDrawer(typeof(ReadOnlyEnumFlagsAttribute))]
     public class ReadOnlyEnumFlagsDrawer : PropertyDrawer

--- a/1-Scripts/Runtime/GPUInstancer/AB_GPUInstancerPrefabManager.cs
+++ b/1-Scripts/Runtime/GPUInstancer/AB_GPUInstancerPrefabManager.cs
@@ -1,5 +1,7 @@
 using GPUInstancer;
+#if ODIN_INSPECTOR
 using Sirenix.OdinInspector;
+#endif
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -8,13 +10,16 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 #endif
 
-namespace ANkleBreaker.GPUInstancer
+namespace AnkleBreaker.GPUInstancer
 {
     [RequireComponent(typeof(GPUInstancerPrefabManager))]
     public class AB_GPUInstancerPrefabManager : MonoBehaviour
     {
-        [InfoBox("$" + nameof(_errorMessage), InfoMessageType.Error, nameof(FoundError))] [SerializeField]
+#if ODIN_INSPECTOR
+        [InfoBox("$" + nameof(_errorMessage), InfoMessageType.Error, nameof(FoundError))]
         [ReadOnly]
+#endif
+        [SerializeField]
         private GPUInstancerPrefabManager _gpuInstancerPrefabManager;
 
         public bool FoundError { get; private set; }
@@ -38,7 +43,9 @@ namespace ANkleBreaker.GPUInstancer
 
         #region Editor
 
+#if ODIN_INSPECTOR
         [OnInspectorInit]
+#endif
         private void OnInspectorInit()
         {
             #if UNITY_EDITOR
@@ -51,13 +58,17 @@ namespace ANkleBreaker.GPUInstancer
             #endif
         }
         
+#if ODIN_INSPECTOR
         [Button]
+#endif
         public void CheckErrors()
         {
             CheckRegisteredPrefabs();
         }
 
+#if ODIN_INSPECTOR
         [Button("Register Instances in Scene & Save")]
+#endif
         public void RegisterInstancesInSceneAndSave()
         {
             CleanRegisteredPrefabs();
@@ -68,7 +79,9 @@ namespace ANkleBreaker.GPUInstancer
             CheckErrors();
         }
 
+#if ODIN_INSPECTOR
         [Button]
+#endif
         private void CleanRegisteredPrefabs()
         {
             InitGPUInstancerPrefabManager();

--- a/1-Scripts/Runtime/GPUInstancer/AnkleBreaker.Utils.GPUInstancer.asmdef
+++ b/1-Scripts/Runtime/GPUInstancer/AnkleBreaker.Utils.GPUInstancer.asmdef
@@ -15,6 +15,12 @@
     "defineConstraints": [
         "GPU_INSTANCER"
     ],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.sirenix.odin-inspector",
+            "expression": "",
+            "define": "ODIN_INSPECTOR"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/1-Scripts/Runtime/Utilities/Global/ExtensionMethods/Built-inTypes_Extensions/ColliderExtensions.cs
+++ b/1-Scripts/Runtime/Utilities/Global/ExtensionMethods/Built-inTypes_Extensions/ColliderExtensions.cs
@@ -48,7 +48,7 @@ namespace AnkleBreaker.Utils.ExtensionMethods.BuiltIn_Types
         public static void SetCollidersEnablementState(this GameObject obj, IList<bool> enablement)
         {
             Collider[] colliders = obj.GetComponentsInChildren<Collider>();
-            int max = Mathf.Max(colliders.Length, enablement.Count);
+            int max = Mathf.Min(colliders.Length, enablement.Count);
             for (int i = 0; i < max; i++)
                 colliders[i].enabled = enablement[i];
         }

--- a/1-Scripts/Runtime/Utilities/Global/Inspector/Attributes/ReadOnlyEnumDrawer.cs
+++ b/1-Scripts/Runtime/Utilities/Global/Inspector/Attributes/ReadOnlyEnumDrawer.cs
@@ -3,7 +3,10 @@ using UnityEngine;
 using UnityEditor;
 #endif
 
-public class ReadOnlyEnumFlagsAttribute : PropertyAttribute
+namespace AnkleBreaker.Utils.Inspector
 {
+    public class ReadOnlyEnumFlagsAttribute : PropertyAttribute
+    {
     
+    }
 }

--- a/1-Scripts/Runtime/Wwise/AKAmbientLODs.cs
+++ b/1-Scripts/Runtime/Wwise/AKAmbientLODs.cs
@@ -1,6 +1,8 @@
 using System.Collections;
 using System.Linq;
+#if ODIN_INSPECTOR
 using Sirenix.OdinInspector;
+#endif
 using UnityEngine;
 
 #if UNITY_EDITOR
@@ -14,7 +16,9 @@ namespace AnkleBreaker.Utils.Wwise
     public class AKAmbientLODs : MonoBehaviour
     {
 #if UNITY_EDITOR
+#if ODIN_INSPECTOR
         [OnInspectorGUI]
+#endif
         private void OnInspectorGUI()
         {
             EditorGUILayout.HelpBox("This script is a server version of AKAmbientLODs, it contains no logic ! Should not be used on server", MessageType.Warning);
@@ -42,16 +46,30 @@ namespace AnkleBreaker.Utils.Wwise
         private int _tickOffset;
         private int _currentTick;
 
+#if ODIN_INSPECTOR
         [Sirenix.OdinInspector.ReadOnly, ShowInInspector]
+#endif
         private bool _isActive;
 
+#if ODIN_INSPECTOR
         [Sirenix.OdinInspector.ReadOnly, SerializeField, OnInspectorInit(nameof(InitAkAmbient))]
+#else
+        [SerializeField]
+#endif
         private AkAmbient _ambient;
 
+#if ODIN_INSPECTOR
         [SerializeField] [ValueDropdown(nameof(InitTriggerDropDown))]
+#else
+        [SerializeField]
+#endif
         private uint _triggerType;
 
-        [SerializeReference,Sirenix.OdinInspector.ReadOnly, HideInInspector]
+#if ODIN_INSPECTOR
+        [SerializeReference, Sirenix.OdinInspector.ReadOnly, HideInInspector]
+#else
+        [SerializeReference, HideInInspector]
+#endif
         private System.Collections.Generic.Dictionary<uint, string> _triggerTypes;
 
         private void InitAkAmbient()
@@ -60,7 +78,9 @@ namespace AnkleBreaker.Utils.Wwise
             _ambient = GetComponent<AkAmbient>();
         }
 
+#if ODIN_INSPECTOR
         [Sirenix.OdinInspector.Button]
+#endif
         private void SetupTrigger()
         {
             _triggerType = (uint)_ambient.triggerList[0];
@@ -70,6 +90,7 @@ namespace AnkleBreaker.Utils.Wwise
         private void Start()
         {
             InitCamera();
+            InitAkAmbient();
             _current = transform;
             if (_refreshRate > 1)
             {
@@ -130,6 +151,7 @@ namespace AnkleBreaker.Utils.Wwise
             }
         }
 
+#if ODIN_INSPECTOR
         private IEnumerable InitTriggerDropDown()
         {
             ValueDropdownList<uint> triggerDropDownList = new ValueDropdownList<uint>();
@@ -141,6 +163,7 @@ namespace AnkleBreaker.Utils.Wwise
 
             return triggerDropDownList;
         }
+#endif
         
         private void InitCamera()
         {

--- a/1-Scripts/Runtime/Wwise/AnkleBreaker.Utils.Wwise.asmdef
+++ b/1-Scripts/Runtime/Wwise/AnkleBreaker.Utils.Wwise.asmdef
@@ -13,6 +13,12 @@
     "defineConstraints": [
         "AB_WWISE"
     ],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.sirenix.odin-inspector",
+            "expression": "",
+            "define": "ODIN_INSPECTOR"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.11] - 2026-02-28
+
+* FIX: Remove merge conflict markers from CHANGELOG
+* FIX: Move ReadOnlyEnumFlagsAttribute from global namespace to AnkleBreaker.Utils.Inspector
+* FIX: Wrap EnumWithDescriptionDrawer in #if ODIN_INSPECTOR guard to prevent compile errors without Odin
+* FIX: ColliderExtensions.SetCollidersEnablementState IndexOutOfRange (Mathf.Max -> Mathf.Min)
+* FIX: Add #if ODIN_INSPECTOR guards to AB_GPUInstancerPrefabManager and fix namespace typo (ANkleBreaker -> AnkleBreaker)
+* FIX: Add #if ODIN_INSPECTOR guards to AKAmbientLODs
+* Add Odin Inspector versionDefines to GPUInstancer and Wwise assembly definitions
+
 ## [0.0.10] - 2025-04-15
 
 * Create EnumDescriptionAttribute to draw an info box related to the selected enum entry 
@@ -27,20 +37,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Add ReadOnly enum inspector attribute 
 
-## [0.0.8] - 2025-03-24
-
-* Add MonoScriptFinder to find a mono script in assets
-* Remove !UNITY_SERVER defines on WwiseUtils 
-
-## [0.0.7] - 2025-02-24
-
-* Add AKAmbientLOD use to enable/disable AKAmbient based on distance to camera 
-
-## [0.0.6] - 2025-01-27
-
-* Add ReadOnly enum inspector attribute 
-
->>>>>>> Development
 ## [0.0.5] - 2024-08-23
 
 * Add TextCompletion attribute that show a text area with text completion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.anklebreaker-studio.utils",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "displayName": "AnkleBreaker-studio Utils",
   "description": "AnkleBreaker-studio Utils contains some utils scripts of the AnkleBreaker team",
   "unity": "2022.3",


### PR DESCRIPTION
## Summary

- Fix namespace inconsistencies (ReadOnlyEnumDrawer, GPUInstancer typo)
- Add #if ODIN_INSPECTOR guards on all Odin-dependent code (GPUInstancer, Wwise, EnumWithDescriptionDrawer)
- Add versionDefines for Odin in GPUInstancer and Wwise assembly definitions
- Fix Mathf.Max -> Mathf.Min bug in ColliderExtensions.SetCollidersEnablementState
- Resolve merge conflict in CHANGELOG.md
- Bump version to 0.0.11
